### PR TITLE
No debug on stdout

### DIFF
--- a/source/BCU-console/Program.cs
+++ b/source/BCU-console/Program.cs
@@ -192,8 +192,10 @@ Return codes:
 
                     foreach (var error in task.AllUninstallersList.Where(x =>
                         x.CurrentStatus != UninstallStatus.Completed && x.CurrentError != null))
+                    {
                         Console.WriteLine("Error: {0} - {1}", error.UninstallerEntry.DisplayName,
                             error.CurrentError.Message);
+                    }
                 }
             };
             task.Start();
@@ -224,22 +226,31 @@ Return codes:
 
             Console.WriteLine("Looking for applications...");
             string previousMain = null;
-            var result = ApplicationUninstallerFactory.GetUninstallerEntries(report =>
+
+            IList<ApplicationUninstallerEntry> result;
+            if (isQuiet || isUnattended)
             {
-                if (previousMain != report.Message)
-                {
-                    previousMain = report.Message;
-                    Console.WriteLine(report.Message);
-                }
-                if (isVerbose)
-                {
-                    if (!string.IsNullOrEmpty(report.Inner?.Message))
-                    {
-                        Console.Write("-> ");
-                        Console.WriteLine(report.Inner.Message);
-                    }
-                }
-            });
+                result = ApplicationUninstallerFactory.GetUninstallerEntries(null);
+            }
+            else
+            {
+                result = ApplicationUninstallerFactory.GetUninstallerEntries(report =>
+                            {
+                                if (previousMain != report.Message)
+                                {
+                                    previousMain = report.Message;
+                                    Console.WriteLine(report.Message);
+                                }
+                                if (isVerbose)
+                                {
+                                    if (!string.IsNullOrEmpty(report.Inner?.Message))
+                                    {
+                                        Console.Write("-> ");
+                                        Console.WriteLine(report.Inner.Message);
+                                    }
+                                }
+                            });
+            }
 
             Console.WriteLine("Found {0} applications.", result.Count);
             return result;

--- a/source/UninstallTools/Dialogs/StartupManagerWindow.cs
+++ b/source/UninstallTools/Dialogs/StartupManagerWindow.cs
@@ -72,7 +72,7 @@ namespace UninstallTools.Dialogs
             }
             catch (Exception e)
             {
-                Console.WriteLine(e);
+                Debug.WriteLine(e);
             }
             return window;
         }

--- a/source/UninstallTools/Factory/ApplicationUninstallerFactory.cs
+++ b/source/UninstallTools/Factory/ApplicationUninstallerFactory.cs
@@ -59,7 +59,7 @@ namespace UninstallTools.Factory
                         regProgress.Inner = report;
                         callback?.Invoke(regProgress);
                     });
-                    Console.WriteLine($"[Performance] Factory {typeof(RegistryFactory).Name} took {sw.ElapsedMilliseconds}ms to finish");
+                    Debug.WriteLine($"[Performance] Factory {typeof(RegistryFactory).Name} took {sw.ElapsedMilliseconds}ms to finish");
 
                     // Fill in install llocations for DirectoryFactory to improve speed and quality of results
                     if (UninstallToolsGlobalConfig.UninstallerFactoryCache != null)
@@ -94,7 +94,7 @@ namespace UninstallTools.Factory
                         driveProgress.Inner = report;
                         callback?.Invoke(driveProgress);
                     });
-                    Console.WriteLine($"[Performance] Factory {typeof(DirectoryFactory).Name} took {sw.ElapsedMilliseconds}ms to finish");
+                    Debug.WriteLine($"[Performance] Factory {typeof(DirectoryFactory).Name} took {sw.ElapsedMilliseconds}ms to finish");
                 }
                 else
                 {
@@ -151,7 +151,7 @@ namespace UninstallTools.Factory
                     }
                     catch (SystemException e)
                     {
-                        Console.WriteLine("Failed to save cache: " + e);
+                        Debug.WriteLine("Failed to save cache: " + e);
                     }
                 }
 
@@ -245,7 +245,7 @@ namespace UninstallTools.Factory
                     Debug.WriteLine("Cache miss: " + entry.DisplayName);
                 }
             }
-            Console.WriteLine($"Cache hits: {hits}/{baseEntries.Count}");
+            Debug.WriteLine($"Cache hits: {hits}/{baseEntries.Count}");
         }
 
         private static List<ApplicationUninstallerEntry> GetMiscUninstallerEntries(ListGenerationProgress.ListGenerationCallback? progressCallback)
@@ -266,7 +266,7 @@ namespace UninstallTools.Factory
                 {
                     var sw = Stopwatch.StartNew();
                     MergeResults(otherResults, kvp.GetUninstallerEntries(null), null);
-                    Console.WriteLine($"[Performance] Factory {kvp.DisplayName} took {sw.ElapsedMilliseconds}ms to finish");
+                    Debug.WriteLine($"[Performance] Factory {kvp.DisplayName} took {sw.ElapsedMilliseconds}ms to finish");
                 }
                 catch (Exception ex)
                 {

--- a/source/UninstallTools/Factory/ChocolateyFactory.cs
+++ b/source/UninstallTools/Factory/ChocolateyFactory.cs
@@ -53,7 +53,7 @@ namespace UninstallTools.Factory
             }
             catch (SystemException ex)
             {
-                Console.WriteLine(ex);
+                Debug.WriteLine(ex);
             }
         }
 
@@ -151,7 +151,7 @@ namespace UninstallTools.Factory
                 }
                 catch (SystemException ex)
                 {
-                    Console.WriteLine(@"Exception while extracting info from choco: " + ex.Message);
+                    Debug.WriteLine(@"Exception while extracting info from choco: " + ex.Message);
                 }
             }
         }
@@ -196,7 +196,7 @@ namespace UninstallTools.Factory
             {
                 var sw = Stopwatch.StartNew();
                 var output = process?.StandardOutput.ReadToEnd();
-                Console.WriteLine($"[Performance] Running command {filename} {args} took {sw.ElapsedMilliseconds}ms");
+                Debug.WriteLine($"[Performance] Running command {filename} {args} took {sw.ElapsedMilliseconds}ms");
                 return output;
             }
         }

--- a/source/UninstallTools/Factory/DirectoryFactory.cs
+++ b/source/UninstallTools/Factory/DirectoryFactory.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Klocman.Extensions;
@@ -37,7 +38,7 @@ namespace UninstallTools.Factory
             var itemsToScan = GetDirectoriesToScan(existingUninstallers, pfDirs, dirsToSkip).ToList();
             return FactoryThreadedHelpers.DriveApplicationScan(progressCallback, dirsToSkip, itemsToScan);
         }
-        
+
         public static IEnumerable<ApplicationUninstallerEntry> TryGetApplicationsFromDirectories(
             ICollection<DirectoryInfo> directoriesToScan, IEnumerable<ApplicationUninstallerEntry> existingUninstallers)
         {
@@ -101,7 +102,7 @@ namespace UninstallTools.Factory
                             }
                             catch (SystemException ex)
                             {
-                                Console.WriteLine(ex);
+                                Debug.WriteLine(ex);
                             }
                             break;
 
@@ -135,7 +136,7 @@ namespace UninstallTools.Factory
                 }
                 catch (SystemException ex)
                 {
-                    Console.WriteLine($"Could not access a program files directory: {x.Key?.Name} | Reason:{ex.Message}");
+                    Debug.WriteLine($"Could not access a program files directory: {x.Key?.Name} | Reason:{ex.Message}");
                 }
                 return Enumerable.Empty<KVP>();
             });

--- a/source/UninstallTools/Factory/FactoryThreadedHelpers.cs
+++ b/source/UninstallTools/Factory/FactoryThreadedHelpers.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Management;
@@ -48,8 +49,8 @@ namespace UninstallTools.Factory
             return results;
         }
 
-        public static void GenerateMisingInformation(IList<ApplicationUninstallerEntry> entries, 
-            InfoAdderManager infoAdder, IList<Guid> msiProducts, bool skipRunLast, 
+        public static void GenerateMisingInformation(IList<ApplicationUninstallerEntry> entries,
+            InfoAdderManager infoAdder, IList<Guid> msiProducts, bool skipRunLast,
             ListGenerationProgress.ListGenerationCallback progressCallback)
         {
             void WorkLogic(ApplicationUninstallerEntry entry, object state)
@@ -74,7 +75,7 @@ namespace UninstallTools.Factory
                     }
                     catch (SystemException ex)
                     {
-                        Console.WriteLine(ex);
+                        Debug.WriteLine(ex);
                     }
                 }
                 return cDrive;
@@ -126,7 +127,7 @@ namespace UninstallTools.Factory
             }
             catch (SystemException ex)
             {
-                Console.WriteLine(@"Failed to get logical disk to physical drive relationships - " + ex);
+                Debug.WriteLine(@"Failed to get logical disk to physical drive relationships - " + ex);
                 output.Clear();
                 output.Add(itemsToScan);
             }

--- a/source/UninstallTools/Factory/FactoryTools.cs
+++ b/source/UninstallTools/Factory/FactoryTools.cs
@@ -37,7 +37,7 @@ namespace UninstallTools.Factory
                 {
                     var sw = Stopwatch.StartNew();
                     var output = process?.StandardOutput.ReadToEnd();
-                    Console.WriteLine($"[Performance] Running command {filename} {args} took {sw.ElapsedMilliseconds}ms");
+                    Debug.WriteLine($"[Performance] Running command {filename} {args} took {sw.ElapsedMilliseconds}ms");
                     return process?.ExitCode == 0 ? output : null;
                 }
                 catch (Win32Exception ex)

--- a/source/UninstallTools/Factory/InfoAdders/FastSizeGenerator.cs
+++ b/source/UninstallTools/Factory/InfoAdders/FastSizeGenerator.cs
@@ -27,7 +27,7 @@ namespace UninstallTools.Factory.InfoAdders
             }
             catch (Exception ex)
             {
-                Console.WriteLine(@"FastSizeGenerator: Scripting.FileSystemObjectClass is not available - " + ex.Message);
+                Debug.WriteLine(@"FastSizeGenerator: Scripting.FileSystemObjectClass is not available - " + ex.Message);
             }
 
             try
@@ -40,7 +40,7 @@ namespace UninstallTools.Factory.InfoAdders
             catch (SystemException ex)
             {
                 _everythingAvailable = false;
-                Console.WriteLine(@"FastSizeGenerator: Everything search engine is not available - " + ex.Message);
+                Debug.WriteLine(@"FastSizeGenerator: Everything search engine is not available - " + ex.Message);
             }
         }
 
@@ -58,7 +58,7 @@ namespace UninstallTools.Factory.InfoAdders
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine(ex);
+                    Debug.WriteLine(ex);
                     _everythingAvailable = false;
                 }
             }
@@ -73,7 +73,7 @@ namespace UninstallTools.Factory.InfoAdders
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine(ex);
+                    Debug.WriteLine(ex);
                 }
             }
         }

--- a/source/UninstallTools/Factory/InfoAdders/SimpleDeleteUninstallStringGenerator.cs
+++ b/source/UninstallTools/Factory/InfoAdders/SimpleDeleteUninstallStringGenerator.cs
@@ -4,6 +4,7 @@
 */
 
 using System;
+using System.Diagnostics;
 using System.IO;
 
 namespace UninstallTools.Factory.InfoAdders
@@ -21,7 +22,7 @@ namespace UninstallTools.Factory.InfoAdders
             }
             catch (Exception e)
             {
-                Console.WriteLine(e);
+                Debug.WriteLine(e);
 
                 UniversalUninstallerFilename = null;
                 UniversalUninstallerIsAvailable = false;

--- a/source/UninstallTools/Factory/RegistryFactory.cs
+++ b/source/UninstallTools/Factory/RegistryFactory.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Security;
@@ -78,7 +79,7 @@ namespace UninstallTools.Factory
                 catch (Exception ex)
                 {
                     //Uninstaller is invalid or there is no uninstaller in the first place. Skip it to avoid problems.
-                    Console.WriteLine($@"Failed to extract reg entry {data.Key.Name} - {ex}");
+                    Debug.WriteLine($@"Failed to extract reg entry {data.Key.Name} - {ex}");
                 }
                 finally
                 {

--- a/source/UninstallTools/Factory/ScoopFactory.cs
+++ b/source/UninstallTools/Factory/ScoopFactory.cs
@@ -57,7 +57,7 @@ namespace UninstallTools.Factory
             }
             catch (SystemException ex)
             {
-                Console.WriteLine(ex);
+                Debug.WriteLine(ex);
             }
         }
 
@@ -161,7 +161,7 @@ namespace UninstallTools.Factory
             {
                 var sw = Stopwatch.StartNew();
                 var output = process?.StandardOutput.ReadToEnd();
-                Console.WriteLine($"[Performance] Running command {startInfo.FileName} {startInfo.Arguments} took {sw.ElapsedMilliseconds}ms");
+                Debug.WriteLine($"[Performance] Running command {startInfo.FileName} {startInfo.Arguments} took {sw.ElapsedMilliseconds}ms");
                 return output;
             }
         }

--- a/source/UninstallTools/Factory/ScriptFactory.cs
+++ b/source/UninstallTools/Factory/ScriptFactory.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.Linq;
@@ -66,7 +67,7 @@ namespace UninstallTools.Factory
                     }
                     catch (SystemException ex)
                     {
-                        Console.WriteLine(ex);
+                        Debug.WriteLine(ex);
                     }
                 }
 

--- a/source/UninstallTools/Junk/Containers/RunProcessJunk.cs
+++ b/source/UninstallTools/Junk/Containers/RunProcessJunk.cs
@@ -38,7 +38,7 @@ namespace UninstallTools.Junk.Containers
             }
             catch (SystemException ex)
             {
-                Console.WriteLine(ex);
+                Debug.WriteLine(ex);
             }
         }
 

--- a/source/UninstallTools/Junk/Finders/Drive/CommonDriveJunkScanner.cs
+++ b/source/UninstallTools/Junk/Finders/Drive/CommonDriveJunkScanner.cs
@@ -90,7 +90,7 @@ namespace UninstallTools.Junk.Finders.Drive
             catch (Exception ex)
             {
                 if (Debugger.IsAttached) throw;
-                Console.WriteLine(ex);
+                Debug.WriteLine(ex);
             }
 
             return results;

--- a/source/UninstallTools/Junk/Finders/Drive/PrefetchScanner.cs
+++ b/source/UninstallTools/Junk/Finders/Drive/PrefetchScanner.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Klocman.Extensions;
@@ -44,7 +45,7 @@ namespace UninstallTools.Junk.Finders.Drive
             }
             catch (SystemException ex)
             {
-                Console.WriteLine("Failed to gather prefetch files - " + ex);
+                Debug.WriteLine("Failed to gather prefetch files - " + ex);
             }
         }
 

--- a/source/UninstallTools/Junk/Finders/Drive/UninstallerLocationScanner.cs
+++ b/source/UninstallTools/Junk/Finders/Drive/UninstallerLocationScanner.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Klocman.Extensions;
@@ -28,7 +29,7 @@ namespace UninstallTools.Junk.Finders.Drive
         {
             var uninLoc = target.UninstallerLocation;
             if (string.IsNullOrEmpty(uninLoc)) yield break;
-            
+
             if (_allProgramFiles.Any(x => uninLoc.StartsWith(x, StringComparison.InvariantCultureIgnoreCase))
                 && !CheckIfDirIsStillUsed(uninLoc, GetOtherInstallLocations(target)))
             {
@@ -47,7 +48,7 @@ namespace UninstallTools.Junk.Finders.Drive
                 }
                 catch (SystemException e)
                 {
-                    Console.WriteLine(e);
+                    Debug.WriteLine(e);
                     yield break;
                 }
 

--- a/source/UninstallTools/Junk/Finders/Misc/ShortcutJunk.cs
+++ b/source/UninstallTools/Junk/Finders/Misc/ShortcutJunk.cs
@@ -36,7 +36,7 @@ namespace UninstallTools.Junk.Finders.Misc
             }
             catch (Exception ex)
             {
-                Console.WriteLine(ex);
+                Debug.WriteLine(ex);
                 Debug.Fail(ex.ToString());
             }
             return Enumerable.Empty<string>();
@@ -68,8 +68,8 @@ namespace UninstallTools.Junk.Finders.Misc
                 catch (Exception ex)
                 {
                     var failMessage = "Failed to resolve shortcut: " + linkFilename;
-                    Console.WriteLine(failMessage);
-                    Console.WriteLine(ex);
+                    Debug.WriteLine(failMessage);
+                    Debug.WriteLine(ex);
                     Debug.Fail(failMessage);
                 }
             }

--- a/source/UninstallTools/Junk/Finders/Registry/AudioPolicyConfigScanner.cs
+++ b/source/UninstallTools/Junk/Finders/Registry/AudioPolicyConfigScanner.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using Klocman.Extensions;
 using Klocman.Tools;
@@ -28,7 +29,7 @@ namespace UninstallTools.Junk.Finders.Registry
 
             if (string.IsNullOrEmpty(target.InstallLocation))
                 return returnList;
-            
+
             string pathRoot;
 
             try
@@ -37,7 +38,7 @@ namespace UninstallTools.Junk.Finders.Registry
             }
             catch (SystemException ex)
             {
-                Console.WriteLine(ex);
+                Debug.WriteLine(ex);
                 return returnList;
             }
 

--- a/source/UninstallTools/Junk/Finders/Registry/ComScanner.cs
+++ b/source/UninstallTools/Junk/Finders/Registry/ComScanner.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Klocman.Tools;
@@ -40,7 +41,7 @@ namespace UninstallTools.Junk.Finders.Registry
                 if (UninstallToolsGlobalConfig.IsSystemDirectory(target.InstallLocation))
                     yield break;
             }
-            catch (ArgumentException ex) { Console.WriteLine(ex); }
+            catch (ArgumentException ex) { Debug.WriteLine(ex); }
 
             foreach (var comEntry in _comEntries.Where(x => PathTools.SubPathIsInsideBasePath(target.InstallLocation, x.FullFilename, true)))
             {
@@ -149,8 +150,8 @@ namespace UninstallTools.Junk.Finders.Registry
                     }
                     catch (SystemException ex)
                     {
-                        Console.WriteLine(@"Unexpected error while scanning COM entries, the registry might be corrupted. COM junk detection will not work.");
-                        Console.WriteLine(ex);
+                        Debug.WriteLine(@"Unexpected error while scanning COM entries, the registry might be corrupted. COM junk detection will not work.");
+                        Debug.WriteLine(ex);
                     }
                 }
             }
@@ -225,7 +226,7 @@ namespace UninstallTools.Junk.Finders.Registry
                     }
                     catch (SystemException ex)
                     {
-                        Console.WriteLine($@"Crash while processing COM GUID: {clsidGuid} - {ex}");
+                        Debug.WriteLine($@"Crash while processing COM GUID: {clsidGuid} - {ex}");
                     }
                     finally
                     {

--- a/source/UninstallTools/Junk/Finders/Registry/DebugTracingScanner.cs
+++ b/source/UninstallTools/Junk/Finders/Registry/DebugTracingScanner.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Security;
@@ -36,7 +37,7 @@ namespace UninstallTools.Junk.Finders.Registry
             }
             catch (SystemException ex)
             {
-                Console.WriteLine(ex);
+                Debug.WriteLine(ex);
                 return returnList;
             }
 
@@ -76,7 +77,7 @@ namespace UninstallTools.Junk.Finders.Registry
             catch (Exception ex)
             {
                 if (ex is UnauthorizedAccessException || ex is SecurityException || ex is IOException)
-                    Console.WriteLine(ex);
+                    Debug.WriteLine(ex);
                 else
                     throw;
             }

--- a/source/UninstallTools/Junk/Finders/Registry/FirewallRuleScanner.cs
+++ b/source/UninstallTools/Junk/Finders/Registry/FirewallRuleScanner.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using Klocman.Extensions;
 using Klocman.Tools;
 using UninstallTools.Junk.Confidence;
@@ -57,7 +58,7 @@ namespace UninstallTools.Junk.Finders.Registry
             }
             catch (SystemException ex)
             {
-                Console.WriteLine(ex);
+                Debug.WriteLine(ex);
                 return null;
             }
         }

--- a/source/UninstallTools/Junk/Finders/Registry/HeapLeakDetectionScanner.cs
+++ b/source/UninstallTools/Junk/Finders/Registry/HeapLeakDetectionScanner.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Klocman.Extensions;
@@ -30,7 +31,7 @@ namespace UninstallTools.Junk.Finders.Registry
             }
             catch (SystemException ex)
             {
-                Console.WriteLine(ex);
+                Debug.WriteLine(ex);
             }
         }
 

--- a/source/UninstallTools/Junk/Finders/Registry/UninstallerKeySearcher.cs
+++ b/source/UninstallTools/Junk/Finders/Registry/UninstallerKeySearcher.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Klocman.Extensions;
@@ -52,7 +53,7 @@ namespace UninstallTools.Junk.Finders.Registry
             }
             catch (SystemException ex)
             {
-                Console.WriteLine(ex);
+                Debug.WriteLine(ex);
             }
         }
 

--- a/source/UninstallTools/Junk/ProgramFilesOrphans.cs
+++ b/source/UninstallTools/Junk/ProgramFilesOrphans.cs
@@ -117,7 +117,7 @@ namespace UninstallTools.Junk
             catch (Exception ex)
             {
                 if (Debugger.IsAttached) throw;
-                Console.WriteLine(ex);
+                Debug.WriteLine(ex);
             }
         }
 

--- a/source/UninstallTools/Startup/Browser/BrowserEntryFactory.cs
+++ b/source/UninstallTools/Startup/Browser/BrowserEntryFactory.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using Klocman.Extensions;
 using Klocman.Tools;
 using Microsoft.Win32;
@@ -37,7 +38,7 @@ namespace UninstallTools.Startup.Browser
                     }
                     catch (UnauthorizedAccessException e)
                     {
-                        Console.WriteLine(e);
+                        Debug.WriteLine(e);
                         continue;
                     }
 

--- a/source/UninstallTools/Startup/Normal/NewStartupDisable.cs
+++ b/source/UninstallTools/Startup/Normal/NewStartupDisable.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using Klocman.Extensions;
 using Klocman.Tools;
@@ -74,18 +75,18 @@ namespace UninstallTools.Startup.Normal
             {
                 using (var key = RegistryTools.CreateSubKeyRecursively(GetStartupApprovedKey(startupEntry)))
                 {
-                    return key.GetValue(startupEntry.EntryLongName) is byte[] bytes 
-                        && bytes.Length > 0 
+                    return key.GetValue(startupEntry.EntryLongName) is byte[] bytes
+                        && bytes.Length > 0
                         && !bytes[0].Equals(0x02);
                 }
             }
             catch (SystemException ex)
             {
-                Console.WriteLine(ex);
+                Debug.WriteLine(ex);
                 return false;
             }
         }
-        
+
         private static string GetStartupApprovedKey(StartupEntry startupEntry)
         {
             if (!startupEntry.IsRegKey)

--- a/source/UninstallTools/Startup/Normal/OldStartupDisable.cs
+++ b/source/UninstallTools/Startup/Normal/OldStartupDisable.cs
@@ -113,7 +113,7 @@ namespace UninstallTools.Startup.Normal
 #if DEBUG
                     Debug.Fail(errorString);
 #else
-                    Console.WriteLine(errorString);
+                    Debug.WriteLine(errorString);
 #endif
                 }
             }

--- a/source/UninstallTools/Startup/Normal/StartupEntryFactory.cs
+++ b/source/UninstallTools/Startup/Normal/StartupEntryFactory.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Security;
@@ -45,7 +46,7 @@ namespace UninstallTools.Startup.Normal
             new StartupPointData(true, false, false, false, @"Common\Startup",
                 WindowsTools.GetEnvironmentPath(CSIDL.CSIDL_COMMON_STARTUP))
         }.AsEnumerable();
-        
+
         /// <summary>
         ///     Look for and return all of the startup entries stored in Startup folders and Run/RunOnce registry keys.
         /// </summary>
@@ -121,7 +122,7 @@ namespace UninstallTools.Startup.Normal
             }
             catch (SecurityException ex)
             {
-                Console.WriteLine(@"Failed to process startup entries: " + ex);
+                Debug.WriteLine(@"Failed to process startup entries: " + ex);
             }
 
             return results;

--- a/source/UninstallTools/Startup/Service/ServiceEntryFactory.cs
+++ b/source/UninstallTools/Startup/Service/ServiceEntryFactory.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Management;
 using System.Runtime.InteropServices;
@@ -25,13 +26,13 @@ namespace UninstallTools.Startup.Service
         }
 
         /* ServiceType
-        Kernel Driver 
-        File System Driver 
-        Adapter 
-        Recognizer Driver 
-        Own Process 
-        Share Process 
-        Interactive Process 
+        Kernel Driver
+        File System Driver
+        Adapter
+        Recognizer Driver
+        Own Process
+        Share Process
+        Interactive Process
         */
 
         public static IEnumerable<ServiceEntry> GetServiceEntries()
@@ -65,8 +66,8 @@ namespace UninstallTools.Startup.Service
             }
             catch (Exception ex) when (ex is TypeInitializationException || ex is ManagementException || ex is ExternalException)
             {
-                Console.Write(@"Error while gathering services - ");
-                Console.WriteLine(ex);
+                Debug.Write(@"Error while gathering services - ");
+                Debug.WriteLine(ex);
             }
 
             return results.ToArray();

--- a/source/UninstallTools/ThreadedWorkSpreader.cs
+++ b/source/UninstallTools/ThreadedWorkSpreader.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 
@@ -79,7 +80,7 @@ namespace UninstallTools
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine(ex);
+                    Debug.WriteLine(ex);
                 }
 
             return _workers.Select(x => x.State);

--- a/source/UninstallTools/UninstallToolsGlobalConfig.cs
+++ b/source/UninstallTools/UninstallToolsGlobalConfig.cs
@@ -101,7 +101,7 @@ namespace UninstallTools
             catch (SystemException e)
             {
                 UninstallerFactoryCache = new ApplicationUninstallerFactoryCache(cachePath);
-                Console.WriteLine(e);
+                Debug.WriteLine(e);
             }
         }
 

--- a/source/UninstallTools/Uninstaller/BulkUninstallEntry.cs
+++ b/source/UninstallTools/Uninstaller/BulkUninstallEntry.cs
@@ -458,7 +458,7 @@ namespace UninstallTools.Uninstaller
             catch (Exception ex)
             {
                 error = ex;
-                Console.WriteLine(@$"Exception when uninstalling {UninstallerEntry.DisplayName}: {ex}");
+                Debug.WriteLine(@$"Exception when uninstalling {UninstallerEntry.DisplayName}: {ex}");
             }
             finally
             {

--- a/source/UninstallTools/Uninstaller/BulkUninstallTask.cs
+++ b/source/UninstallTools/Uninstaller/BulkUninstallTask.cs
@@ -215,8 +215,8 @@ namespace UninstallTools.Uninstaller
             }
             catch (SystemException ex)
             {
-                Console.WriteLine(@"Failed to peacefully close automatizer daemon");
-                Console.WriteLine(ex);
+                Debug.WriteLine(@"Failed to peacefully close automatizer daemon");
+                Debug.WriteLine(ex);
 
                 try { _quietUninstallDaemonProcess?.Kill(); }
                 catch (SystemException) { }
@@ -249,8 +249,8 @@ namespace UninstallTools.Uninstaller
                     {
                         UninstallToolsGlobalConfig.UseQuietUninstallDaemon = false;
 
-                        Console.WriteLine(@"Failed to connect to automatization daemon");
-                        Console.WriteLine(ex);
+                        Debug.WriteLine(@"Failed to connect to automatization daemon");
+                        Debug.WriteLine(ex);
 
                         StopAutomationDaemon();
                     }
@@ -259,8 +259,8 @@ namespace UninstallTools.Uninstaller
                 {
                     UninstallToolsGlobalConfig.UseQuietUninstallDaemon = false;
 
-                    Console.WriteLine(@"Failed to start automatization daemon");
-                    Console.WriteLine(ex);
+                    Debug.WriteLine(@"Failed to start automatization daemon");
+                    Debug.WriteLine(ex);
                 }
             }
         }


### PR DESCRIPTION
The library UninsallTools should not contain `Console.Write*` methods as it should be up to the application using the library. Since those are also used for performance metrics and other debug purposes, I used `Debug.Write*` methods. Also, I allowed null callback just for a really quiet experience.