### PR TITLE
Fix publish script after v6.1

### DIFF
--- a/publish.bat
+++ b/publish.bat
@@ -5,19 +5,28 @@ rem Release Debug
 set config=Release
 
 set msbuild="D:\Applications\VS2022\MSBuild\Current\Bin\amd64\MSBuild.exe"
+if not exist %msbuild% call :findMsbuild
+if not exist %msbuild% (
+	echo Failed to locate MSBuild.exe. Update publish.bat.
+	pause
+	exit /b 1
+)
+
+set solutionDir=%CD%\source\
 set publish=%CD%\bin\publish
 
 set netVer=net8.0
 set netVerFull=net8.0-windows10.0.18362.0
 
-rmdir /q /s "%publish%"
-if errorlevel 1 (pause)
-rmdir /q /s bin\launcher
-if errorlevel 1 (pause)
+if exist "%publish%" rmdir /q /s "%publish%"
+if errorlevel 1 (pause & exit /b 1)
+if exist bin\launcher rmdir /q /s bin\launcher
+if errorlevel 1 (pause & exit /b 1)
 
 
 set platform=x64
 call :publish
+if errorlevel 1 (pause & exit /b 1)
 
 rem Since BCU is now on .NET8, realistically only Arm64 and x64 Windows systems are supported now, so there's no point in building x86
 rem set platform=x86
@@ -29,7 +38,7 @@ copy "%target%\Licence.txt" "%publish%\Licence.txt"
 copy "%target%\PrivacyPolicy.txt" "%publish%\PrivacyPolicy.txt"
 copy "%target%\NOTICE" "%publish%\NOTICE"
 
-rmdir /q /s bin\launcher
+if exist bin\launcher rmdir /q /s bin\launcher
 
 IF %config%==Release (del /f /s /q "%publish%\*.pdb")
 
@@ -38,17 +47,22 @@ rem --- AnyCPU --------------------------------------------------
 
 set target=%CD%\bin\publish-AnyCPU-%netVer%
 
-rmdir /q /s "%target%"
-if errorlevel 1 (pause)
+if exist "%target%" rmdir /q /s "%target%"
+if errorlevel 1 (pause & exit /b 1)
+
+set platform=Any CPU
+set selfContained=False
+set runtime=
 
 echo ====== Building AnyCPU ======
 
-%msbuild% "source\BulkCrapUninstaller.sln" /p:filealignment=512 /t:Publish /p:DeployOnBuild=true /p:PublishSingleFile=False /p:SelfContained=False /p:PublishProtocol=FileSystem /p:Configuration=%config% /p:Platform="Any CPU" /p:TargetFrameworks=%netVerFull% /p:PublishDir="%target%"  /p:PublishReadyToRun=false /p:PublishTrimmed=False /verbosity:minimal
+call :publishProjects
+if errorlevel 1 (pause & exit /b 1)
 
 IF %config%==Release (del /f /s /q "%target%\*.pdb")
 
 pause
-exit
+exit /b 0
 
 
 
@@ -57,12 +71,68 @@ rem -------------------------------------------------------------
 :publish
 set identifier=win-%platform%
 set target=%CD%\bin\publish\%identifier%
+set selfContained=True
+set runtime=/p:RuntimeIdentifier=%identifier%
 
 echo ====== Building %identifier% ======
 
-%msbuild% "source\BulkCrapUninstaller.sln" /p:filealignment=512 /t:Restore;Rebuild /p:DeployOnBuild=true /p:PublishSingleFile=False /p:SelfContained=True /p:PublishProtocol=FileSystem /p:Configuration=%config% /p:Platform=%platform% /p:TargetFrameworks=%netVerFull% /p:PublishDir="%target%" /p:RuntimeIdentifier=%identifier% /p:PublishReadyToRun=false /p:PublishTrimmed=False /verbosity:minimal
+call :buildLauncher
+if errorlevel 1 goto :eof
 
-%msbuild% "source\BulkCrapUninstaller.sln" /p:filealignment=512 /t:Publish /p:DeployOnBuild=true /p:PublishSingleFile=False /p:SelfContained=True /p:PublishProtocol=FileSystem /p:Configuration=%config% /p:Platform=%platform% /p:TargetFrameworks=%netVerFull% /p:PublishDir="%target%" /p:RuntimeIdentifier=%identifier% /p:PublishReadyToRun=false /p:PublishTrimmed=False /verbosity:minimal
+call :publishProjects
+goto :eof
+
+rem -------------------------------------------------------------
+
+:publishProjects
+call :publishProject "source\BulkCrapUninstaller\BulkCrapUninstaller.csproj"
+if errorlevel 1 goto :eof
+call :publishProject "source\BCU-console\BCU-console.csproj"
+if errorlevel 1 goto :eof
+call :publishProject "source\OculusHelper\OculusHelper.csproj"
+if errorlevel 1 goto :eof
+call :publishProject "source\ScriptHelper\ScriptHelper.csproj"
+if errorlevel 1 goto :eof
+call :publishProject "source\StoreAppHelper\StoreAppHelper.csproj"
+if errorlevel 1 goto :eof
+call :publishProject "source\SteamHelper\SteamHelper.csproj"
+if errorlevel 1 goto :eof
+call :publishProject "source\WinUpdateHelper\WinUpdateHelper.csproj"
+if errorlevel 1 goto :eof
+call :publishProject "source\UniversalUninstaller\UniversalUninstaller.csproj"
+if errorlevel 1 goto :eof
+call :publishProject "source\UninstallerAutomatizer\UninstallerAutomatizer.csproj"
+
+goto :eof
+
+:publishProject
+%msbuild% "%~1" /restore /m /p:filealignment=512 /t:Publish /p:DeployOnBuild=true /p:PublishSingleFile=False /p:SelfContained=%selfContained% /p:PublishProtocol=FileSystem /p:Configuration=%config% /p:Platform="%platform%" /p:TargetFramework=%netVerFull% /p:PublishDir="%target%" %runtime% /p:PublishReadyToRun=false /p:PublishTrimmed=False /verbosity:minimal
+
+goto :eof
+
+rem -------------------------------------------------------------
+
+:buildLauncher
+%msbuild% "source\BCU-launcher\BCU-launcher.vcxproj" /m /p:Configuration=%config% /p:Platform=x64 /p:SolutionDir=%solutionDir% /verbosity:minimal
+
+goto :eof
+
+rem -------------------------------------------------------------
+
+:findMsbuild
+set vswhere=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe
+
+if exist "%vswhere%" (
+	for /f "delims=" %%I in ('"%vswhere%" -latest -products * -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\amd64\MSBuild.exe') do (
+		set msbuild="%%~fI"
+		goto :eof
+	)
+)
+
+for /f "delims=" %%I in ('where msbuild 2^>nul') do (
+	set msbuild="%%~fI"
+	goto :eof
+)
 
 goto :eof
 

--- a/publish.bat
+++ b/publish.bat
@@ -92,25 +92,21 @@ goto :eof
 rem -------------------------------------------------------------
 
 :publishProjects
-call :publishProject "source\BulkCrapUninstaller\BulkCrapUninstaller.csproj"
-if errorlevel 1 goto :eof
-call :publishProject "source\BCU-console\BCU-console.csproj"
-if errorlevel 1 goto :eof
-call :publishProject "source\OculusHelper\OculusHelper.csproj"
-if errorlevel 1 goto :eof
-call :publishProject "source\ScriptHelper\ScriptHelper.csproj"
-if errorlevel 1 goto :eof
-call :publishProject "source\StoreAppHelper\StoreAppHelper.csproj"
-if errorlevel 1 goto :eof
-call :publishProject "source\SteamHelper\SteamHelper.csproj"
-if errorlevel 1 goto :eof
-call :publishProject "source\WinUpdateHelper\WinUpdateHelper.csproj"
-if errorlevel 1 goto :eof
-call :publishProject "source\UniversalUninstaller\UniversalUninstaller.csproj"
-if errorlevel 1 goto :eof
-call :publishProject "source\UninstallerAutomatizer\UninstallerAutomatizer.csproj"
+for /r "%solutionDir%" %%F in (*.csproj) do (
+	call :publishProjectIfEligible "%%~fF"
+	if errorlevel 1 goto :eof
+)
 
-goto :eof
+exit /b 0
+
+:publishProjectIfEligible
+findstr /i /c:"exe</OutputType>" "%~1" >nul
+if errorlevel 1 exit /b 0
+
+call :publishProject "%~1"
+if errorlevel 1 exit /b 1
+
+exit /b 0
 
 :publishProject
 %msbuild% "%~1" /restore /m /p:filealignment=512 /t:Publish /p:DeployOnBuild=true /p:PublishSingleFile=False /p:SelfContained=%selfContained% /p:PublishProtocol=FileSystem /p:Configuration=%config% /p:Platform="%platform%" /p:TargetFramework=%netVerFull% /p:PublishDir="%target%" %runtime% /p:PublishReadyToRun=false /p:PublishTrimmed=False /verbosity:minimal
@@ -120,7 +116,8 @@ goto :eof
 rem -------------------------------------------------------------
 
 :buildLauncher
-%msbuild% "source\BCU-launcher\BCU-launcher.vcxproj" /m /p:Configuration=%config% /p:Platform=x64 "/p:SolutionDir=%solutionDir%\\" /verbosity:minimal
+rem Build via solution so platform mapping is respected automatically.
+%msbuild% "source\BulkCrapUninstaller.sln" /t:BCU-launcher /m /p:Configuration=%config% /p:Platform=%platform% "/p:SolutionDir=%solutionDir%\\" /verbosity:minimal
 
 goto :eof
 

--- a/publish.bat
+++ b/publish.bat
@@ -18,10 +18,14 @@ set publish=%CD%\bin\publish
 set netVer=net8.0
 set netVerFull=net8.0-windows10.0.18362.0
 
-if exist "%publish%" rmdir /q /s "%publish%"
-if errorlevel 1 (pause & exit /b 1)
-if exist bin\launcher rmdir /q /s bin\launcher
-if errorlevel 1 (pause & exit /b 1)
+if exist "%publish%" (
+	rmdir /q /s "%publish%"
+	if errorlevel 1 (pause & exit /b 1)
+)
+if exist bin\launcher (
+	rmdir /q /s bin\launcher
+	if errorlevel 1 (pause & exit /b 1)
+)
 
 
 set platform=x64
@@ -32,7 +36,8 @@ rem Since BCU is now on .NET8, realistically only Arm64 and x64 Windows systems 
 rem set platform=x86
 rem call :publish
 
-copy bin\launcher\BCU-launcher.exe %publish%\BCUninstaller.exe
+copy bin\launcher\BCU-launcher.exe "%publish%\BCUninstaller.exe"
+if errorlevel 1 (echo Failed to copy BCU-launcher.exe & pause & exit /b 1)
 copy "%target%\BCU_manual.html" "%publish%\BCU_manual.html"
 copy "%target%\Licence.txt" "%publish%\Licence.txt"
 copy "%target%\PrivacyPolicy.txt" "%publish%\PrivacyPolicy.txt"
@@ -47,8 +52,10 @@ rem --- AnyCPU --------------------------------------------------
 
 set target=%CD%\bin\publish-AnyCPU-%netVer%
 
-if exist "%target%" rmdir /q /s "%target%"
-if errorlevel 1 (pause & exit /b 1)
+if exist "%target%" (
+	rmdir /q /s "%target%"
+	if errorlevel 1 (pause & exit /b 1)
+)
 
 set platform=Any CPU
 set selfContained=False
@@ -113,7 +120,7 @@ goto :eof
 rem -------------------------------------------------------------
 
 :buildLauncher
-%msbuild% "source\BCU-launcher\BCU-launcher.vcxproj" /m /p:Configuration=%config% /p:Platform=x64 /p:SolutionDir=%solutionDir% /verbosity:minimal
+%msbuild% "source\BCU-launcher\BCU-launcher.vcxproj" /m /p:Configuration=%config% /p:Platform=x64 /p:SolutionDir="%solutionDir%" /verbosity:minimal
 
 goto :eof
 

--- a/publish.bat
+++ b/publish.bat
@@ -12,7 +12,7 @@ if not exist %msbuild% (
 	exit /b 1
 )
 
-set solutionDir=%CD%\source\
+set solutionDir=%CD%\source
 set publish=%CD%\bin\publish
 
 set netVer=net8.0
@@ -120,7 +120,7 @@ goto :eof
 rem -------------------------------------------------------------
 
 :buildLauncher
-%msbuild% "source\BCU-launcher\BCU-launcher.vcxproj" /m /p:Configuration=%config% /p:Platform=x64 /p:SolutionDir="%solutionDir%" /verbosity:minimal
+%msbuild% "source\BCU-launcher\BCU-launcher.vcxproj" /m /p:Configuration=%config% /p:Platform=x64 "/p:SolutionDir=%solutionDir%\\" /verbosity:minimal
 
 goto :eof
 

--- a/publish.bat
+++ b/publish.bat
@@ -68,6 +68,7 @@ if errorlevel 1 (pause & exit /b 1)
 
 IF %config%==Release (del /f /s /q "%target%\*.pdb")
 
+echo ====== Publishing finished! ======
 pause
 exit /b 0
 


### PR DESCRIPTION
Previously, `publish.bat` published the whole solution with `msbuild BulkCrapUninstaller.sln /t:Publish /m`. In v6.1, `/m` was removed to avoid the resulting random failures.

This PR keeps the script close to the original, but changes the publish flow to publish the intended applications one project at a time. It still uses `/m` inside each individual project build, restores MSBuild auto-discovery, switches the publish call to `TargetFramework`, and fixes a few small error-handling and path-quoting issues.

The problem was solution-level parallel publish, not parallelism itself. Serializing the top-level publishes avoids collisions in shared `obj` and publish outputs, while keeping safe parallelism within each project build.