### PR TITLE
feat(UninstallerType): detect Squirrel/Electron auto-updater installs (fixes half of #949)

### DIFF
--- a/source/UninstallTools/Factory/InfoAdders/UninstallerTypeAdder.cs
+++ b/source/UninstallTools/Factory/InfoAdders/UninstallerTypeAdder.cs
@@ -72,6 +72,14 @@ namespace UninstallTools.Factory.InfoAdders
                 uninstallString.Contains(".ps1", StringComparison.OrdinalIgnoreCase))
                 return UninstallerType.PowerShell;
 
+            // Detect Squirrel / Electron auto-updater installs
+            // e.g. "C:\Users\<u>\AppData\Local\<Vendor>\<App>\Update.exe --uninstall -s"
+            // Discord, GitHub Desktop, Slack (classic), Teams (classic), many Electron apps
+            if (uninstallString.Contains("Update.exe", StringComparison.OrdinalIgnoreCase)
+                && uninstallString.Contains("--uninstall", StringComparison.OrdinalIgnoreCase)
+                && uninstallString.Contains(@"\AppData\Local\", StringComparison.OrdinalIgnoreCase))
+                return UninstallerType.Squirrel;
+
             if (ProcessStartCommand.TryParse(uninstallString, out var ps) 
                 && Path.IsPathRooted(ps.FileName) 
                 && File.Exists(ps.FileName))

--- a/source/UninstallTools/Properties/Localisation.Designer.cs
+++ b/source/UninstallTools/Properties/Localisation.Designer.cs
@@ -1238,6 +1238,15 @@ namespace UninstallTools.Properties {
                 return ResourceManager.GetString("UninstallerType_PowerShell", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Squirrel (Electron).
+        /// </summary>
+        internal static string UninstallerType_Squirrel {
+            get {
+                return ResourceManager.GetString("UninstallerType_Squirrel", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to SDBInst.

--- a/source/UninstallTools/Properties/Localisation.resx
+++ b/source/UninstallTools/Properties/Localisation.resx
@@ -574,6 +574,9 @@
   <data name="UninstallerType_PowerShell" xml:space="preserve">
     <value>PowerShell script</value>
   </data>
+  <data name="UninstallerType_Squirrel" xml:space="preserve">
+    <value>Squirrel (Electron)</value>
+  </data>
   <data name="Junk_DebugTracing_GroupName" xml:space="preserve">
     <value>Debug Tracing/Logging Configuration</value>
   </data>

--- a/source/UninstallTools/UninstallerType.cs
+++ b/source/UninstallTools/UninstallerType.cs
@@ -37,6 +37,8 @@ namespace UninstallTools
         [LocalisedName(typeof(Localisation), "UninstallerType_Oculus")]
         Oculus,
         [LocalisedName(typeof(Localisation), nameof(Localisation.UninstallerType_PowerShell))]
-        PowerShell
+        PowerShell,
+        [LocalisedName(typeof(Localisation), nameof(Localisation.UninstallerType_Squirrel))]
+        Squirrel
     }
 }


### PR DESCRIPTION
## Summary

Adds detection for **Squirrel / Electron auto-updater installers**, a common class of modern Windows apps (Discord, GitHub Desktop, Slack classic, Teams classic, many Electron apps).

Their `UninstallString` is a stable pattern:

```
"C:\Users\<user>\AppData\Local\<Vendor>\<App>\Update.exe" --uninstall -s
```

Today BCU classifies these as `Unknown` (there's no matching branch in `UninstallerTypeAdder.GetUninstallerType`), which loses useful signal in the UI and blocks per-type filtering.

## Changes

1. **`source/UninstallTools/UninstallerType.cs`** — add `Squirrel` enum value after `PowerShell` (+2 lines with the `LocalisedName` attribute).
2. **`source/UninstallTools/Factory/InfoAdders/UninstallerTypeAdder.cs`** — new detection branch, mirrors the existing `PowerShell` / `Chocolatey` shape (+7 lines).
3. **`source/UninstallTools/Properties/Localisation.resx`** — one string: `UninstallerType_Squirrel` → `"Squirrel (Electron)"` (+3 lines).
4. **`source/UninstallTools/Properties/Localisation.Designer.cs`** — matching accessor generated in the same style as `UninstallerType_PowerShell` (+9 lines).

Total: **23 lines added, 1 replaced** across 4 files. No behavioural change for any existing uninstaller — Squirrel apps previously matched no branch and returned `Unknown`.

## Detection logic

```csharp
// Detect Squirrel / Electron auto-updater installs
// e.g. "C:\Users\<u>\AppData\Local\<Vendor>\<App>\Update.exe --uninstall -s"
// Discord, GitHub Desktop, Slack (classic), Teams (classic), many Electron apps
if (uninstallString.Contains("Update.exe", StringComparison.OrdinalIgnoreCase)
    && uninstallString.Contains("--uninstall", StringComparison.OrdinalIgnoreCase)
    && uninstallString.Contains(@"\AppData\Local\", StringComparison.OrdinalIgnoreCase))
    return UninstallerType.Squirrel;
```

The `\AppData\Local\` clause avoids the (rare) case of a legit non-Squirrel `Update.exe --uninstall` living in `Program Files` or another install root.

## Out of scope

- **Junk scan integration.** `SpecificUninstallerKindScanner` doesn't yet have a Squirrel case (%LocalAppData% leftovers, `SquirrelTemp` folders, `stubexecutable` shortcuts). Leaving as a follow-up so this PR stays surgical and reviewable.
- **Package-manager delegation** (e.g. asking winget to uninstall these when they were installed via `winget install Discord.Discord`) — see #948, separate concern.

## Related

Fixes half of [#949](https://github.com/BCUninstaller/Bulk-Crap-Uninstaller/issues/949) (detection half; junk-scan half left open there).

## Test plan

- Build `source/BulkCrapUninstaller.sln`
- Scan a machine with Discord, GitHub Desktop, or Slack Classic installed
- Confirm the affected rows now show "Squirrel (Electron)" in the "Uninstaller type" column instead of "Unknown"
- Confirm all other rows are unchanged
