### PR TITLE
fix(factory): skip symlinks/junctions during directory scan (fixes #690)

### DIFF
--- a/source/UninstallTools/Factory/InfoAdders/AppExecutablesSearcher.cs
+++ b/source/UninstallTools/Factory/InfoAdders/AppExecutablesSearcher.cs
@@ -77,7 +77,8 @@ namespace UninstallTools.Factory.InfoAdders
 
         internal static ScanDirectoryResult ScanDirectory(DirectoryInfo directory)
         {
-            var results = new List<FileInfo>(directory.GetFiles("*.exe", SearchOption.TopDirectoryOnly));
+            var results = new List<FileInfo>(directory.GetFiles("*.exe", SearchOption.TopDirectoryOnly)
+                .Where(f => (f.Attributes & FileAttributes.ReparsePoint) == 0));
             var binSubdirs = new List<DirectoryInfo>();
             var otherSubdirs = new List<DirectoryInfo>();
             var maybeSubdirs = new List<DirectoryInfo>();
@@ -85,11 +86,18 @@ namespace UninstallTools.Factory.InfoAdders
             {
                 try
                 {
+                    // Skip symlinks / junctions / other reparse points to prevent
+                    // duplicate entries and infinite recursion when a link points
+                    // back inside the scan tree (issue #690).
+                    if ((subdir.Attributes & FileAttributes.ReparsePoint) != 0)
+                        continue;
+
                     var subName = subdir.Name;
                     if (subName.StartsWithAny(BinaryDirectoryNames, StringComparison.OrdinalIgnoreCase))
                     {
                         binSubdirs.Add(subdir);
-                        results.AddRange(subdir.GetFiles("*.exe", SearchOption.TopDirectoryOnly));
+                        results.AddRange(subdir.GetFiles("*.exe", SearchOption.TopDirectoryOnly)
+                            .Where(f => (f.Attributes & FileAttributes.ReparsePoint) == 0));
                     }
                     else
                     {


### PR DESCRIPTION
## Summary

Skip symbolic links and directory junctions when scanning `InstallLocation` for executables. Fixes #690.

## Problem

BCU currently enumerates `.exe` files and subdirectories with `directory.GetFiles(...)` / `directory.GetDirectories()` and treats each result as if it were regular content. If a symlink or junction points at another location, BCU:

1. Adds a duplicate entry pointing at the linked target
2. In the worst case (link points back inside the scan tree), recurses into the same content the parent scan already covered

Report: [#690](https://github.com/BCUninstaller/Bulk-Crap-Uninstaller/issues/690).

## Fix

In `AppExecutablesSearcher.ScanDirectory`:

- Filter top-level `.exe` matches with `(f.Attributes & FileAttributes.ReparsePoint) == 0`
- Filter `.exe` matches inside recognised binary subdirectories with the same check
- Skip whole subdirectories that are reparse points before recursing / classifying them

`FileAttributes.ReparsePoint` covers symlinks (created with `mklink` / `New-Item -ItemType SymbolicLink`) and directory junctions (created with `mklink /J`).

## Changes

| File | Δ |
|---|---|
| `source/UninstallTools/Factory/InfoAdders/AppExecutablesSearcher.cs` | +10, -2 |

Net 8 lines. No changes to behaviour for regular files/directories.

## Test plan

- Create a scenario with a symlink inside `InstallLocation`:
  ```
  mklink /D "C:\Program Files\SomeApp\linked" "C:\some\other\dir"
  ```
- Scan with BCU
- Before this fix: `SortedExecutables` includes `.exe` files from the linked target and duplicates any dupes
- After: `SortedExecutables` is unchanged as if `linked/` did not exist

## Related

- Fixes #690.
- Companion PR #951 (Squirrel/Electron detection, fixes half of #949) is independent — different branch, different concern.
