### PR TITLE
Uninstall: Execute the Confirmed Directory Entry

### DIFF
--- a/source/BulkCrapUninstaller/Functions/AppUninstaller.cs
+++ b/source/BulkCrapUninstaller/Functions/AppUninstaller.cs
@@ -549,7 +549,7 @@ namespace BulkCrapUninstaller.Functions
                 else
                 {
 
-                    foreach (var item in items)
+                    foreach (var item in items.ToList())
                     {
                         if (item.UninstallPossible && item.UninstallerKind != UninstallerType.SimpleDelete &&
                             MessageBoxes.UninstallFromDirectoryUninstallerFound(item.DisplayName, item.UninstallString))

--- a/source/BulkCrapUninstaller/Functions/AppUninstaller.cs
+++ b/source/BulkCrapUninstaller/Functions/AppUninstaller.cs
@@ -549,7 +549,7 @@ namespace BulkCrapUninstaller.Functions
                 else
                 {
 
-                    foreach (var item in items.ToList())
+                    foreach (var item in items)
                     {
                         if (item.UninstallPossible && item.UninstallerKind != UninstallerType.SimpleDelete &&
                             MessageBoxes.UninstallFromDirectoryUninstallerFound(item.DisplayName, item.UninstallString))
@@ -573,7 +573,7 @@ namespace BulkCrapUninstaller.Functions
                                 if (entry.UninstallPossible && entry.UninstallerKind != UninstallerType.SimpleDelete &&
                                     MessageBoxes.UninstallFromDirectoryUninstallerFound(entry.DisplayName, entry.UninstallString))
                                 {
-                                    try { item.RunUninstaller(false, Settings.Default.AdvancedSimulate).WaitForExit(60000); }
+                                    try { entry.RunUninstaller(false, Settings.Default.AdvancedSimulate).WaitForExit(60000); }
                                     catch (Exception ex) { PremadeDialogs.GenericError(ex); }
 
                                     listRefreshNeeded = true;


### PR DESCRIPTION
This pull request corrects the nested directory-uninstall path. When BCU matches a discovered directory item to a registered application entry, the confirmation dialog displays the registered entry but the previous code executed the discovered item's uninstaller. The patch changes the call so the displayed and executed entries are the same.
The change is intentionally limited to the incorrect object reference. Validate it using the simulation-mode directory-uninstall flow. Add automated regression coverage only if a small test seam is accepted; do not broaden this one-line correctness change into UI refactoring.