### PR TITLE
CI: Pin Actions and Publish Windows Test Results

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
 
   build:
     runs-on: windows-2022
-    
+
     steps:
     - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
     
@@ -27,12 +27,28 @@ jobs:
            msbuild source\BulkCrapUninstaller.sln /t:Publish /p:Configuration=Release /p:Platform="Any CPU" /verbosity:minimal
            /p:filealignment=512 /p:DeployOnBuild=true /p:PublishSingleFile=False /p:SelfContained=False /p:PublishReadyToRun=false /p:PublishTrimmed=False
            /p:PublishProtocol=FileSystem /p:PublishDir="${{ github.workspace }}\bin\publish"
-           
+
     - name: Build launcher
       run: >
            msbuild "source\BCU-launcher\BCU-launcher.vcxproj" /t:Build /p:Configuration=Release /p:Platform=Win32 /m /verbosity:minimal
-    
+
     - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.event.repository.name }}_${{ github.sha }}
         path: bin\publish
+
+    - name: Test
+      run: >
+           dotnet test source\BulkCrapUninstallerTests\BulkCrapUninstallerTests.csproj
+           --configuration Release
+           --no-restore
+           --logger "trx;LogFileName=BulkCrapUninstallerTests.trx"
+           --results-directory "${{ github.workspace }}\TestResults"
+
+    - name: Upload test results
+      if: always()
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      with:
+        name: windows-test-results_${{ github.sha }}
+        path: TestResults\*.trx
+        if-no-files-found: warn

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,15 +6,18 @@ on:
     - master
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
 
   build:
     runs-on: windows-2022
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
     
-    - uses: microsoft/setup-msbuild@v2
+    - uses: microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce # v2
 
     - name: Restore
       run: msbuild source\BulkCrapUninstaller.sln /t:Restore /p:Configuration=Release /p:Platform="Any CPU" /verbosity:minimal
@@ -29,7 +32,7 @@ jobs:
       run: >
            msbuild "source\BCU-launcher\BCU-launcher.vcxproj" /t:Build /p:Configuration=Release /p:Platform=Win32 /m /verbosity:minimal
     
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ github.event.repository.name }}_${{ github.sha }}
         path: bin\publish

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -2,6 +2,10 @@ name: Publish to WinGet
 on:
   release:
     types: [released]
+
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -11,8 +15,12 @@ jobs:
         run: |
           # Find the version from tag name and pad to 4 components
           version=$(echo "${{ github.event.release.tag_name }}" | awk -F. '{printf "%d.%d.%d.%d\n", substr($1, 2), $2, $3, $4}')
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-      - uses: vedantmgoyal9/winget-releaser@main
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid release tag: ${{ github.event.release.tag_name }}" >&2
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+      - uses: vedantmgoyal9/winget-releaser@b3a5dae0047c6180023acba3f548c55fdf6b7193 # immutable pin; review updates through a dependency PR
         with:
           identifier: Klocman.BulkCrapUninstaller
           version: ${{ steps.get-version.outputs.version }}


### PR DESCRIPTION
This pull request strengthens the existing CI and WinGet release workflows without changing application runtime behavior. It replaces mutable action tags with immutable commit references, restricts default workflow permissions to read-only repository contents, corrects the WinGet version-output variable, and fails early when the calculated release version is malformed.

The PR also makes the existing Windows test project part of CI and uploads TRX output even when a test run fails. This creates a practical test signal and preserves failure evidence for review.

Before merge, verify the pinned action commits against their upstream repositories, run the workflow on a non-production branch or test release, confirm a TRX artifact is retained, and rotate or restrict WINGET_TOKEN as appropriate.