### PR TITLE
feat(portable): add Windows ARM64 support to launcher and publish script

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,12 +24,6 @@ jobs:
            msbuild source\BulkCrapUninstaller.sln /t:Publish /p:Configuration=Release /p:Platform="Any CPU" /verbosity:minimal
            /p:filealignment=512 /p:DeployOnBuild=true /p:PublishSingleFile=False /p:SelfContained=False /p:PublishReadyToRun=false /p:PublishTrimmed=False
            /p:PublishProtocol=FileSystem /p:PublishDir="${{ github.workspace }}\bin\publish"
-
-    - name: Restore ARM64
-      run: msbuild source\BulkCrapUninstaller.sln /t:Restore /p:Configuration=Release /p:Platform=ARM64 /verbosity:minimal
-
-    - name: Build ARM64
-      run: msbuild source\BulkCrapUninstaller.sln /t:Build /p:Configuration=Release /p:Platform=ARM64 /m /verbosity:minimal
            
     - name: Build launcher
       run: >

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,12 @@ jobs:
            msbuild source\BulkCrapUninstaller.sln /t:Publish /p:Configuration=Release /p:Platform="Any CPU" /verbosity:minimal
            /p:filealignment=512 /p:DeployOnBuild=true /p:PublishSingleFile=False /p:SelfContained=False /p:PublishReadyToRun=false /p:PublishTrimmed=False
            /p:PublishProtocol=FileSystem /p:PublishDir="${{ github.workspace }}\bin\publish"
+
+    - name: Restore ARM64
+      run: msbuild source\BulkCrapUninstaller.sln /t:Restore /p:Configuration=Release /p:Platform=ARM64 /verbosity:minimal
+
+    - name: Build ARM64
+      run: msbuild source\BulkCrapUninstaller.sln /t:Build /p:Configuration=Release /p:Platform=ARM64 /m /verbosity:minimal
            
     - name: Build launcher
       run: >

--- a/publish.bat
+++ b/publish.bat
@@ -32,6 +32,10 @@ set platform=x64
 call :publish
 if errorlevel 1 (pause & exit /b 1)
 
+set platform=ARM64
+call :publish
+if errorlevel 1 (pause & exit /b 1)
+
 rem Since BCU is now on .NET8, realistically only Arm64 and x64 Windows systems are supported now, so there's no point in building x86
 rem set platform=x86
 rem call :publish
@@ -78,6 +82,7 @@ rem -------------------------------------------------------------
 
 :publish
 set identifier=win-%platform%
+if /i "%platform%"=="ARM64" set identifier=win-arm64
 set target=%CD%\bin\publish\%identifier%
 set selfContained=True
 set runtime=/p:RuntimeIdentifier=%identifier%

--- a/source/BCU-launcher/main.cpp
+++ b/source/BCU-launcher/main.cpp
@@ -32,6 +32,19 @@ BOOL Is64BitOS()
 	return bIs64BitOS;
 }
 
+BOOL IsArm64OS()
+{
+	typedef BOOL(WINAPI* LPFN_ISWOW64PROCESS2) (HANDLE, PUSHORT, PUSHORT);
+
+	LPFN_ISWOW64PROCESS2 fnIsWow64Process2 = (LPFN_ISWOW64PROCESS2)GetProcAddress(GetModuleHandle(L"kernel32"), "IsWow64Process2");
+	USHORT processMachine = IMAGE_FILE_MACHINE_UNKNOWN;
+	USHORT nativeMachine = IMAGE_FILE_MACHINE_UNKNOWN;
+
+	return NULL != fnIsWow64Process2
+		&& fnIsWow64Process2(GetCurrentProcess(), &processMachine, &nativeMachine)
+		&& nativeMachine == IMAGE_FILE_MACHINE_ARM64;
+}
+
 std::wstring GetLastErrorAsString()
 {
 	//Get the error message ID, if any.
@@ -90,7 +103,16 @@ int main()
 {
 	std::wstring p;
 
-	if (Is64BitOS())
+	if (IsArm64OS())
+	{
+		p = ExePath() + L"\\win-arm64\\BCUninstaller.exe";
+		if (!fexists(p))
+		{
+			MessageBox(nullptr, L"This installation of BCUninstaller does not have files needed to run on ARM64 versions of Windows.\n\nDownload an ARM64 version of BCUninstaller and try again.", L"Could not start BCUninstaller.", MB_ICONERROR | MB_OK);
+			return 1;
+		}
+	}
+	else if (Is64BitOS())
 	{
 		p = ExePath() + L"\\win-x64\\BCUninstaller.exe";
 		if (!fexists(p))


### PR DESCRIPTION
## Summary

Add native Windows ARM64 support to the portable distribution.

The portable launcher now detects ARM64 Windows with `IsWow64Process2` and starts the native application from `win-arm64`. Existing x64 behavior remains unchanged.

## Changes

- Publish self-contained ARM64 binaries to `win-arm64`.
- Extend the launcher to select `win-arm64/BCUninstaller.exe` on ARM64 Windows.
- Show an architecture-specific error when the ARM64 payload is missing.
- Restore and build the full `Release|ARM64` solution in CI.

## Scope

This PR adds ARM64 support to the portable distribution. Installer packaging is not included.

## Validation

- Built the full solution locally with `Release|ARM64`.
- Ran `publish.bat` successfully.
- Verified that the portable archive contains both `win-x64` and `win-arm64`.
- Verified that the application hosts under `win-arm64` are native ARM64 binaries.
- Ran the published ARM64 `BCU-console help` command successfully.
- Launched the portable build on Windows ARM64 and verified normal operation.