### PR TITLE
Update Ukrainian localization

### DIFF
--- a/source/BulkCrapUninstaller/Forms/Windows/MainWindow.uk.resx
+++ b/source/BulkCrapUninstaller/Forms/Windows/MainWindow.uk.resx
@@ -123,6 +123,9 @@
   <data name="olvColumnPublisher.Text" xml:space="preserve">
     <value>Видавець</value>
   </data>
+  <data name="olvColumnCertificate.Text" xml:space="preserve">
+    <value>Сертифікат</value>
+  </data>
   <data name="olvColumnRating.Text" xml:space="preserve">
     <value>Рейтинг користувачів</value>
   </data>
@@ -158,6 +161,9 @@
   </data>
   <data name="olvColumnSystemComponent.Text" xml:space="preserve">
     <value>Компонент системи</value>
+  </data>
+  <data name="olvColumnIntegrity.Text" xml:space="preserve">
+    <value>Цілісність</value>
   </data>
   <data name="olvColumnProtected.Text" xml:space="preserve">
     <value>Захищено</value>
@@ -314,6 +320,9 @@
   </data>
   <data name="useSystemThemeToolStripMenuItem.Text" xml:space="preserve">
     <value>&amp;Використовувати системну тему</value>
+  </data>
+  <data name="autosizeAllColumnsToolStripMenuItem.Text" xml:space="preserve">
+    <value>Автоматично підібрати ширину всіх стовпців</value>
   </data>
   <data name="viewWindowsStoreAppsToolStripMenuItem.Text" xml:space="preserve">
     <value>Перегляд програм Магазину Windows</value>
@@ -530,6 +539,9 @@
   </data>
   <data name="viewWindowsFeaturesToolStripMenuItem.Text" xml:space="preserve">
     <value>Перегляд компонентів Windows</value>
+  </data>
+  <data name="viewInvalidToolStripMenuItem.Text" xml:space="preserve">
+    <value>Перегляд недійсних</value>
   </data>
   <data name="modifyToolStripMenuItem.Text" xml:space="preserve">
     <value>Змінені</value>

--- a/source/BulkCrapUninstaller/Forms/Windows/SettingsWindow.uk.resx
+++ b/source/BulkCrapUninstaller/Forms/Windows/SettingsWindow.uk.resx
@@ -153,6 +153,9 @@
   <data name="label2.Text" xml:space="preserve">
     <value>Створювати точку відновлення перед видаленням</value>
   </data>
+  <data name="label3.Text" xml:space="preserve">
+    <value>Подвійний клац у списку програм</value>
+  </data>
   <data name="groupBoxMessages.Text" xml:space="preserve">
     <value>Вікна повідомлень</value>
   </data>

--- a/source/BulkCrapUninstaller/Properties/Localisable.uk.resx
+++ b/source/BulkCrapUninstaller/Properties/Localisable.uk.resx
@@ -771,4 +771,31 @@ The lists are separated by a single newline.</comment>
   <data name="UninstallProgressWindow_StatusPuttingToSleepInSeconds" xml:space="preserve">
     <value>Перехід комп'ютера в режим сну через {0}с. Зніміть прапорець сну, щоб скасувати. </value>
   </data>
+  <data name="UninstallerListDoubleClickAction_DoNothing" xml:space="preserve">
+    <value>Нічого не робити</value>
+  </data>
+  <data name="UninstallerListDoubleClickAction_Properties" xml:space="preserve">
+    <value>Відкриває властивості</value>
+  </data>
+  <data name="UninstallerListDoubleClickAction_Uninstall" xml:space="preserve">
+    <value>Видаляє</value>
+  </data>
+  <data name="CertificateColumn_NotFound" xml:space="preserve">
+    <value>Не знайдено</value>
+  </data>
+  <data name="CertificateColumn_Verified" xml:space="preserve">
+    <value>Перевірено</value>
+  </data>
+  <data name="CertificateColumn_Unverified" xml:space="preserve">
+    <value>Не перевірено</value>
+  </data>
+  <data name="IntegrityColumn_Invalid" xml:space="preserve">
+    <value>Відсутній деінсталятор</value>
+  </data>
+  <data name="IntegrityColumn_Unregistered" xml:space="preserve">
+    <value>Не зареєстровано</value>
+  </data>
+  <data name="IntegrityColumn_Good" xml:space="preserve">
+    <value>Добре</value>
+  </data>
 </root>


### PR DESCRIPTION
## Details

- `MainWindow.uk.resx`: added `olvColumnCertificate.Text`, `olvColumnIntegrity.Text`, `autosizeAllColumnsToolStripMenuItem.Text`, `viewInvalidToolStripMenuItem.Text`.
- `SettingsWindow.uk.resx`: added `label3.Text` ("Double clicking in application list").
- `Localisable.uk.resx`: added the shared status strings rendered inside those columns/dropdowns — `CertificateColumn_NotFound/Verified/Unverified`, `IntegrityColumn_Invalid/Unregistered/Good`, and `UninstallerListDoubleClickAction_DoNothing/Properties/Uninstall`.

## Not included

- The main list's "Custom Note" column header and its "Edit note..." context-menu item are hardcoded strings in `MainWindow.Designer.cs` (not read from any `.resx`), so they can't be localized without a separate code change to wire them into the resource system, left out of scope here.

## Test plan

- [x] All modified `.resx` files validated as well-formed XML.
- [x] Manual smoke test: switch app language to Ukrainian and confirm the Certificate/Integrity columns, quick filters, view menu, and Settings → Interface page render translated text with no layout overflow.